### PR TITLE
Hotfix/add yarn lock to docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,8 +3,7 @@
 *docker-compose*
 node_modules
 npm-debug.log
-package-lock.json
-yarn.lock
+yarn-error.log
 docs
 tests
 .deploy


### PR DESCRIPTION
Fixes docker build by providing yarn.lock into context of build (new one is not generated by yarn)
https://travis-ci.org/knit-pk/homepage-nuxtjs/jobs/355092592