### PR TITLE
Add metadata for page with article content

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 .env
 app.js
 .env.mydevil

--- a/src/components/article/ArticleCard.vue
+++ b/src/components/article/ArticleCard.vue
@@ -14,7 +14,7 @@
 
         <!-- Title -->
         <router-link :to="{ path: url }" class="article-card__title-link">
-          <h3 ref="articleTitle" class="article-card__title" itemprop="headline"> {{ ellipsis(title, 75) }} </h3>
+          <h3 ref="articleTitle" class="article-card__title" itemprop="headline"> {{ ellipsify(title, 75) }} </h3>
         </router-link>
 
         <!-- Tags -->
@@ -40,7 +40,7 @@
 
     <!-- Description -->
     <router-link :to="{ path: url }" itemtype="description" class="article-card__description">
-      {{ ellipsis(description, 170) }}
+      {{ ellipsify(description, 170) }}
     </router-link>
 
     <!-- Footer -->

--- a/src/components/article/ArticleContent.vue
+++ b/src/components/article/ArticleContent.vue
@@ -7,7 +7,7 @@
       <div class="article-content__header-info">
 
         <!-- Title -->
-        <h2 class="article-content__title" itemprop="headline"> {{ ellipsis(title, 110) }} </h2>
+        <h2 class="article-content__title" itemprop="headline"> {{ ellipsify(title, 110) }} </h2>
         <div class="article-content__pub-info">
 
           <!-- Author avatar -->

--- a/src/helpers/template.js
+++ b/src/helpers/template.js
@@ -7,8 +7,21 @@ import _ from 'lodash'
  * @param {Number} [length=3]
  * @returns {String}
  */
-function ellipsis (str, length = 3) {
+function ellipsify (str, length = 3) {
   return (length - 3) >= str.length ? str : `${str.slice(0, length - 3)}...`
+}
+
+/**
+ * Returns string with dots if length of a string is too big,
+ * without: words cut in half, trailing punctuations, etc.
+ * @param {String} str
+ * @param {Number} [length=3]
+ * @returns {String}
+ */
+function ellipsifyWithoutResidue (str, length = 3) {
+  const cutResidueRegex = /[\W\u0080-\u00FF\u0100-\u017F]*\s[\S]*$/
+  const slicedStr = str.slice(0, length - 3)
+  return (length - 3) >= str.length ? str : `${slicedStr.replace(cutResidueRegex, '...')}`
 }
 
 /**
@@ -50,7 +63,8 @@ export default {
   methods: {
     formatDateToLocalString,
     defaultCssPostfix,
-    ellipsis,
+    ellipsify,
+    ellipsifyWithoutResidue,
     isUrl,
     capitalize: _.capitalize,
     upper: _.toUpper,

--- a/src/pages/artykuly/_categoryCode/_titleCode/_shortId.vue
+++ b/src/pages/artykuly/_categoryCode/_titleCode/_shortId.vue
@@ -53,6 +53,16 @@ export default {
       code: _.values(params).join('/'),
     })
   },
+  head () {
+    return {
+      title: `${this.article.metaTitle}`,
+      meta: [{
+        hid: 'description',
+        name: 'description',
+        content: `${this.article.metaDescription}`,
+      }],
+    }
+  },
 }
 </script>
 

--- a/src/store/view/articles.js
+++ b/src/store/view/articles.js
@@ -1,5 +1,6 @@
 import knitService from '~/services/knitService'
 import settings from '~/config/store/articles'
+import templateHelper from '~/helpers/template'
 import commonHelper from '~/helpers/common'
 import storeHelper from '~/helpers/store'
 import knitLogger from '~/config/logger'
@@ -32,7 +33,19 @@ const codes = storeHelper.createMutationFn(types.ADD_CODES)
 const customFns = {
   prepareArticles (data) {
     const articlesArr = commonHelper.pickItemsProps(data['hydra:member'], settings.props, true, settings.datePicker)
-    return _.keyBy(articlesArr, 'code')
+    const maxEllipsifiedDescriptionLength = 135
+
+    const articlesArrWithMeta = _.map(articlesArr, (article) => {
+      const ellipsifiedDescription = templateHelper.methods.ellipsifyWithoutResidue(article.description, maxEllipsifiedDescriptionLength)
+
+      return {
+        ...article,
+        metaTitle: `${article.title} | KNIT`,
+        metaDescription: `${article.title}. ${ellipsifiedDescription} | ${article.category.name}`,
+      }
+    })
+
+    return _.keyBy(articlesArrWithMeta, 'code')
   },
 }
 


### PR DESCRIPTION
Metadata is created as follows:
- **title:** article_title | KNIT
- **description:** article_title article_head | article_category_name
where article_head is the first couple of sentences from article - 230 characters with last word cut off, because it can be incomplete.

Corresponding tasks on taiga: [150](https://tree.taiga.io/project/fierycod-knit-front-vuejs/task/150), [151](https://tree.taiga.io/project/fierycod-knit-front-vuejs/task/151).
