### PR TITLE
ci(travis): Fix deploying to mydevil

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,13 +53,13 @@ deploy:
     script: bash ./deploy/mydevil-deploy.sh
     on:
       branch: develop
-      node: '8'
+      condition: $DEPLOY = 1
   - provider: script
     skip_cleanup: true
     script: ssh k911-main@s11.mydevil.net 'bash -s' < ./deploy/mydevil-post-deploy.sh
     on:
       branch: develop
-      node: '8'
+      condition: $DEPLOY = 1
   - provider: script
     skip_cleanup: true
     script: bash ./deploy/github-tag.sh


### PR DESCRIPTION
Node 8 was excluded from travis matrix in https://github.com/knit-pk/homepage-nuxtjs/commit/137c74be2c3cdcbfd2ef9b58dab70dbb788305a3, and since then deploys to mydevil aren't triggered, this fixes it